### PR TITLE
Fix various typos and formatting issues

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,11 +1,9 @@
-# Released under MIT License
+MIT License
 
-Copyright (c) 2013 Mark Otto.
+Copyright (c) 2023-Present St. Jude Children's Research Hospital
 
-Copyright (c) 2017 Andrew Fong.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-A PHP package to transform your gnomics values into permissible values for commonly used CDEs within the CCDI API.
+A PHP package to transform your genomics values into permissible values for commonly used CDEs within the CCDI API.
 
-The values you have within your system may not match the permissible values for the CDEs. This package provides a way to transform your values into permissible values for the CDEs. As well as providing an `AbstractTransformer` class that can be extended to prodice custom transformations.
+The values you have within your system may not match the permissible values for the CDEs. This package provides a way to transform your values into permissible values for the CDEs. As well as providing an `AbstractTransformer` class that can be extended to produce custom transformations.
 
 ## Requirements
 
@@ -12,7 +12,7 @@ This package requires the following to work as expected:
 
 - PHP 8.2.7
 
-Optional:   
+Optional (but recommended):
 
 - PHPUnit ^10.3
 
@@ -36,9 +36,9 @@ $femalePermissibleValue = SexTransformer::transform('FEMALE')['permissible_value
 
 Also see `index.php` for more examples.
 
-## Custom Tranformers
+## Custom Transformers
 
-A demo Customer Transform exists in `src/Demo/AcmeHospital/AcmeSexTransformer.php`. This can be used as a starting point for creating your own custom transformers.
+A demo custom transformer exists in `src/Demo/AcmeHospital/AcmeSexTransformer.php`. This can be used as a starting point for creating your own custom transformers.
 
 This demo transformer has been created to transform the values of `boy` to the CDE value for `Male` and `girl` to the CDE value for `Female`.
 
@@ -64,11 +64,9 @@ class AcmeTissueTypeTransformer extends TissueTypeTransformer
 
 ## CDE Versions
 
-Each CDE's permissible values, long name, concept code, CDE version, description CADsr URL, and public_id are harded coded into a Data class, e.g. `src/CDE/V1/Data/Sex.php`. This is to ensure that the permissible values are always up to date with the CDEs.
+Each CDE's permissible values, long name, concept code, CDE version, description caDSR URL, and public_id are hard-coded into a Data class, e.g. `src/CDE/V1/Data/Sex.php`. This is to ensure that the permissible values are always up to date with the CDEs.
 
 Once a CDE is released, a new version of the package can be released with the new permissible values, long names, etc.
-
-Feel free to create a pull request to add new CDEs.
 
 ## Tests
 

--- a/composer.json
+++ b/composer.json
@@ -10,15 +10,15 @@
         }
     ],
     "autoload": {
-      "psr-4": {
-        "CCDI\\": "src/"
-      }
+        "psr-4": {
+            "CCDI\\": "src/"
+        }
     },
     "require": {
-      "php": ">=8.2.7"
+        "php": ">=8.2.7"
     },
     "require-dev": {
-      "laravel/pint": "^1.15",
+        "laravel/pint": "^1.15",
         "phpunit/phpunit": "^10.3",
         "larastan/larastan": "*"
     }

--- a/src/Demo/AcmeHospital/AcmeSexTransformer.php
+++ b/src/Demo/AcmeHospital/AcmeSexTransformer.php
@@ -13,7 +13,7 @@ class AcmeSexTransformer extends SexTransformer
     public static function getMappings(): array
     {
         // @phpstan-ignore-next-line
-        $mappings = SexSexTransformer::$MAPPINGS;
+        $mappings = SexTransformer::$MAPPINGS;
 
         $mappings[] =
             [


### PR DESCRIPTION
This PR fixes a few typos and formatting issues.

- Updated LICENSE to match what exists in other St. Jude Cloud projects and retrieved the text from https://opensource.org/license/MIT.
- Fixed various typos in README.md
- Ran formatter on `composer.json`
- Fixed typo in demo transformer